### PR TITLE
Sentry SDK & Debugging Failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_STORE*
 __pycache__
 .virtualenv
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .virtualenv
 .env
+nohup.out

--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ Let your job run then Check LCP WebVital for one of your JS transactions:
 
 #### Trends
 ![Trends1](img/trends-1.png)
+
+## Troubleshooting
+Tests may fail intermittently due to instability of connections/selenium/etc. 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ pip install setuptools==44.0.0
 # and re-rerun:
 pip install -r requirements.txt
 ```
+
+Set your `DSN` in:
+```
+touch .env
+```
+This is so any errors occuring in conftest.py (the pytest and updates on selenium jobs) get reported.
+
 # Setup: Setting up cron job to trigger simulations
 
 We can trigger the travis builds on a schedule via Google Cloud Scheduler cron jobs.

--- a/README.md
+++ b/README.md
@@ -83,4 +83,5 @@ Let your job run then Check LCP WebVital for one of your JS transactions:
 ![Trends1](img/trends-1.png)
 
 ## Troubleshooting
-Tests may fail intermittently due to instability of connections/selenium/etc. 
+- Tests may fail intermittently due to instability of connections/selenium/etc. 
+- Using more threads `-n` means more transactions, so less likely to dip below a Low Traffic threshold (metric alert)

--- a/conftest.py
+++ b/conftest.py
@@ -57,9 +57,6 @@ def _generate_param_ids(name, values):
 
 @pytest.yield_fixture(scope='function')
 def driver(request, browser_config):
-    # does not print
-    # print(request.node)
-
     sentry_sdk.capture_message("Started Pytest for node: %s" % (request.node.name))
     # if the assignment below does not make sense to you please read up on object assignments.
     # The point is to make a copy and not mess with the original test spec.

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from os import environ
 import sentry_sdk
 from selenium import webdriver
@@ -93,6 +94,10 @@ def driver(request, browser_config):
     # Teardown starts here
     # report results
     # use the test result to send the pass/fail status to Sauce Labs
+    # TODO what else can be used for debugging from `request.node.rep_call.`
+    # TODO check nohup.out file for output of what went wrong
+    # TODO compare to breadcrumbs recorded by .capture_message
+    # TODO compare to 'invalid selector css' errors in Saucelabs VM
     sauce_result = "failed" if request.node.rep_call.failed else "passed"
     if sauce_result == "failed":
         sentry_sdk.capture_message(sauce_result)

--- a/conftest.py
+++ b/conftest.py
@@ -57,6 +57,8 @@ def _generate_param_ids(name, values):
 
 @pytest.yield_fixture(scope='function')
 def driver(request, browser_config):
+    print(request.node)
+    sentry_sdk.capture_message("Started Pytest: %s" % (request.node.name))
     # if the assignment below does not make sense to you please read up on object assignments.
     # The point is to make a copy and not mess with the original test spec.
     desired_caps = dict()
@@ -87,7 +89,7 @@ def driver(request, browser_config):
     if browser is not None:
         print("SauceOnDemandSessionID={} job-name={}".format(browser.session_id, test_name))
     else:
-        sentry_sdk.capture_message("Never created!")
+        sentry_sdk.capture_message("Never created - case test failed: %s %s" % (browser.session_id, test_name))
         raise WebDriverException("Never created!")
 
     yield browser

--- a/conftest.py
+++ b/conftest.py
@@ -57,8 +57,10 @@ def _generate_param_ids(name, values):
 
 @pytest.yield_fixture(scope='function')
 def driver(request, browser_config):
-    print(request.node)
-    sentry_sdk.capture_message("Started Pytest: %s" % (request.node.name))
+    # does not print
+    # print(request.node)
+
+    sentry_sdk.capture_message("Started Pytest for node: %s" % (request.node.name))
     # if the assignment below does not make sense to you please read up on object assignments.
     # The point is to make a copy and not mess with the original test spec.
     desired_caps = dict()
@@ -102,7 +104,7 @@ def driver(request, browser_config):
     # TODO compare to 'invalid selector css' errors in Saucelabs VM
     sauce_result = "failed" if request.node.rep_call.failed else "passed"
     if sauce_result == "failed":
-        sentry_sdk.capture_message(sauce_result)
+        sentry_sdk.capture_message("Sauce Result: %s %s %s" % (sauce_result, browser.session_id, test_name))
     browser.execute_script("sauce:job-result={}".format(sauce_result))
     browser.quit()
 

--- a/conftest.py
+++ b/conftest.py
@@ -98,10 +98,6 @@ def driver(request, browser_config):
     # Teardown starts here
     # report results
     # use the test result to send the pass/fail status to Sauce Labs
-    # TODO what else can be used for debugging from `request.node.rep_call.`
-    # TODO check nohup.out file for output of what went wrong
-    # TODO compare to breadcrumbs recorded by .capture_message
-    # TODO compare to 'invalid selector css' errors in Saucelabs VM
     sauce_result = "failed" if request.node.rep_call.failed else "passed"
     if sauce_result == "failed":
         sentry_sdk.capture_message("Sauce Result: %s %s %s" % (sauce_result, browser.session_id, test_name))

--- a/endpoints.yaml
+++ b/endpoints.yaml
@@ -1,13 +1,13 @@
 # endpoints should NOT have "/" at the end
 
 react_endpoints:
- - https://neilmanvar-react-m3uuizd7iq-uc.a.run.app/toolstore
- - https://neilmanvar-react-errors-laravel-m3uuizd7iq-uc.a.run.app
- - https://adamtoth-fejel-react-m3uuizd7iq-uc.a.run.app
+# - https://neilmanvar-react-m3uuizd7iq-uc.a.run.app/toolstore
+# - https://neilmanvar-react-errors-laravel-m3uuizd7iq-uc.a.run.app
+# - https://adamtoth-fejel-react-m3uuizd7iq-uc.a.run.app
  - https://wcap-react-m3uuizd7iq-uc.a.run.app/toolstore
 
 backend_endpoints:
- - https://neilmanvar-flask-m3uuizd7iq-uc.a.run.app
- - https://neilmanvar-laravel-errors-m3uuizd7iq-uc.a.run.app
+# - https://neilmanvar-flask-m3uuizd7iq-uc.a.run.app
+# - https://neilmanvar-laravel-errors-m3uuizd7iq-uc.a.run.app
  - https://wcap-flask-m3uuizd7iq-uc.a.run.app
  

--- a/frontend_tests/test_add_to_cart.py
+++ b/frontend_tests/test_add_to_cart.py
@@ -6,6 +6,7 @@ from sentry_sdk import set_tag
 
 @pytest.mark.usefixtures("driver")
 def test_add_to_cart(driver):
+    # TODO, this does not set the tag
     set_tag("test", "test_add_to_cart")
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)

--- a/frontend_tests/test_add_to_cart.py
+++ b/frontend_tests/test_add_to_cart.py
@@ -2,10 +2,11 @@ import pytest
 import time
 import yaml
 import random
+from sentry_sdk import set_tag
 
 @pytest.mark.usefixtures("driver")
 def test_add_to_cart(driver):
-
+    set_tag("test", "test_add_to_cart")
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         endpoints = data_loaded['react_endpoints']

--- a/frontend_tests/test_add_to_cart.py
+++ b/frontend_tests/test_add_to_cart.py
@@ -6,7 +6,6 @@ from sentry_sdk import set_tag
 
 @pytest.mark.usefixtures("driver")
 def test_add_to_cart(driver):
-    # TODO, this does not set the tag
     set_tag("test", "test_add_to_cart")
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)

--- a/nohup.out
+++ b/nohup.out
@@ -1,0 +1,1 @@
+nohup: ./script.sh: Permission denied

--- a/nohup.out
+++ b/nohup.out
@@ -1,1 +1,0 @@
-nohup: ./script.sh: Permission denied

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pytest==4.4.0
 pytest-xdist
 requests
 pyyaml==3.11
+sentry-sdk==0.19.4
+python-dotenv==0.12.0


### PR DESCRIPTION
- instrumented sentry sdk to capture errors from a few places

## debug
compare several things
1. events produced by the demo apps (these are expected)
2. events produced by test-data-automation (now instrumented with `sentry_sdk`, some of these are health checks, others are failtures we're okay with, others are failtures representing real failures). these events go to project `python-test-data-automation`
3. Metric Alerts on project `python-test-data-automation` for Low Traffic / Low Volume
4. can look at the `nohup.out` file.
5. Look at Sauce Labs VM's and the failed nodes/jobs, compare Id's to what's in events from `python-test-data-automation` events.

## todo
- see if anything else on `request.node.rep_call.` can be useful for debugging
- check `nohup.out` file for output of what went wrong, this may match the events captured by sdk, in `python-test-data-automation` project.
- breadcrumbs in events in `python-test-data-automation` reveal which `saucelabs.com` endpoints were failing (non-200 responses)
- compare to 'invalid selector css' errors in Saucelabs VM, are those relevant still? Why doesn't it find the div button?

## Conclusion
- Many possible points of failure, still uncertain what the probably cause was.
- The only info about why Saucelabs VM may have failed, is what SauceLabs sends back to you, which you can log in the pytest. i.e. we don't have an inside look of what's going on inside Saucelab's apps/cloud/VM's, only what they choose to report back to us.
- There are only so many places in the Pytest/selenium tests where an error status regarding a job can be indicated. This PR instrumented sentry_sdk to capture when that is happening. Still need more research on how to coordinate this data against what you can see in Saucelabs

![image](https://user-images.githubusercontent.com/8920574/101712878-1ba2fa00-3a5c-11eb-8a00-f1cf4d1c9d6e.png)
