### PR TITLE
Demo Automation tag and Issue Grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,6 @@ touch .env
 ```
 This is so any errors occuring in conftest.py (the pytest and updates on selenium jobs) get reported.
 
-### Metric Alerts for Low Traffic monitoring
-This is so you can monitor it's running correctly, and get notified if the job stops running.
-```
-event.type:transaction
-transaction:get_tools # the transaction you want to monitor
-function:count() over a 5 minuets window
-
-Critical Status
-Below:2
-```
-The average transactions per 5-minute interval should be between 50 and 200, if you're monitoring it in a Metric Alert.
-
 # Run: Continuously in VM (Compute Engine)
 Use an isolated VM since it's constantly occupying +2 threads simultaneously
 ```
@@ -73,6 +61,17 @@ ps fjx
 kill -9 <PID of the bash process with script.sh>
 ```
 
+## Metric Alerts for Low Traffic monitoring
+This is so you can monitor it's running correctly, and get notified if the job stops running.
+```
+event.type:transaction
+transaction:get_tools # the transaction you want to monitor
+function:count() over a 5 minuets window
+
+Critical Status
+Below:2
+```
+The average transactions per 5-minute interval should be between 50 and 200, if you're monitoring it in a Metric Alert.
 
 ## How to Verify Things are Are Working
 #### WebVitals
@@ -92,8 +91,8 @@ TODO
 - Transaction volume comes from both `frontend_tests` that hit front end apps which then call their corresponding backends, as well as `backend_tests` which only hit the backend apps.
 - Make sure your Metric Alerts are set the same for each project, and you're monitoring the right event type (transactions vs error)
 
-## Setting up GCP cron job to trigger simulations
-**12/11/2020 Update** - This is not actively being used. See Run instructions.
+## Setting up GCP cronjob to trigger simulations
+**12/11/2020 Update** - This GCP cronjob is not actively being used. See Run instructions.
 
 - `create_job.sh` -> creates GCP cron job which hits Travis requests APIs to trigger build
 - `.travis.yml` -> runs automated tests / simulations

--- a/conftest.py
+++ b/conftest.py
@@ -16,8 +16,9 @@ urllib3.disable_warnings()
 sentry_sdk.init(
     dsn= DSN,
     traces_sample_rate=0,
-    environment="prod",
+    environment="prod"
 )
+sentry_sdk.set_tag("demo-automation", "test-data-automation")
 
 browsers = [
     {
@@ -57,7 +58,9 @@ def _generate_param_ids(name, values):
 
 @pytest.yield_fixture(scope='function')
 def driver(request, browser_config):
-    sentry_sdk.capture_message("Started Pytest for node: %s" % (request.node.name))
+    sentry_sdk.set_context("request_node_name", request.node.name)
+    sentry_sdk.capture_message("Started TEST Pytest for node")
+
     # if the assignment below does not make sense to you please read up on object assignments.
     # The point is to make a copy and not mess with the original test spec.
     desired_caps = dict()
@@ -97,10 +100,14 @@ def driver(request, browser_config):
     # use the test result to send the pass/fail status to Sauce Labs
     sauce_result = "failed" if request.node.rep_call.failed else "passed"
     if sauce_result == "failed":
-        sentry_sdk.capture_message("Sauce Result: %s %s %s" % (sauce_result, browser.session_id, test_name))
+        sentry_sdk.set_context("sauce_result", {
+            "browser_session_id", browser.session_id,
+            "test_name", test_name
+        })
+        sentry_sdk.capture_message("Sauce Result: %s" % (sauce_result))
     browser.execute_script("sauce:job-result={}".format(sauce_result))
     browser.quit()
-
+    sentry_sdk.capture_message("Finished browser.quit()")
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_runtest_makereport(item, call):

--- a/conftest.py
+++ b/conftest.py
@@ -58,8 +58,10 @@ def _generate_param_ids(name, values):
 
 @pytest.yield_fixture(scope='function')
 def driver(request, browser_config):
-    sentry_sdk.set_context("request_node_name", request.node.name)
-    sentry_sdk.capture_message("Started TEST Pytest for node")
+    sentry_sdk.set_context("pytest", {
+        "request_node_name": request.node.name
+    })
+    sentry_sdk.capture_message("Started Pytest for node")
 
     # if the assignment below does not make sense to you please read up on object assignments.
     # The point is to make a copy and not mess with the original test spec.
@@ -101,8 +103,8 @@ def driver(request, browser_config):
     sauce_result = "failed" if request.node.rep_call.failed else "passed"
     if sauce_result == "failed":
         sentry_sdk.set_context("sauce_result", {
-            "browser_session_id", browser.session_id,
-            "test_name", test_name
+            "browser_session_id": browser.session_id,
+            "test_name": test_name
         })
         sentry_sdk.capture_message("Sauce Result: %s" % (sauce_result))
     browser.execute_script("sauce:job-result={}".format(sauce_result))


### PR DESCRIPTION
## Done
- `demo-automation: test-data-automation`
- enhanced issue grouping by `set_extra` for 'pytest' start and  'sauce result' in failures.

Single issue for all pystarts and failures, rather than a different one for each hash/id of the nodes/browsers. The string in the issue title was too long and was a stringified object.