### PR TITLE
Less Browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .virtualenv
 .env
 nohup.out
+notes.txt

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Use an isolated VM since it's constantly occupying +2 threads simultaneously
 ```
 source .virtualenv/bin/activate
 nohup ./script.sh &
+
+# writes stdout stderr to null, so don't end up with a nohup.out file that continues growing in size
+nohup ./script.sh >/dev/null 2>&1 &
 ```
 
 How to stop it

--- a/conftest.py
+++ b/conftest.py
@@ -26,11 +26,11 @@ browsers = [
         "platform": "Windows 10",
         "browserName": "chrome",
         "version": "latest"
-    # }, {
-        # "seleniumVersion": '3.4.0',
-        # "platform": "Windows 10",
-        # "browserName": "firefox",
-        # "version": "latest"
+    }, {
+        "seleniumVersion": '3.4.0',
+        "platform": "Windows 10",
+        "browserName": "firefox",
+        "version": "latest"
     }, {
         "seleniumVersion": '3.4.0',
         "platform": "OS X 10.13",

--- a/conftest.py
+++ b/conftest.py
@@ -26,11 +26,11 @@ browsers = [
         "platform": "Windows 10",
         "browserName": "chrome",
         "version": "latest"
-    }, {
-        "seleniumVersion": '3.4.0',
-        "platform": "Windows 10",
-        "browserName": "firefox",
-        "version": "latest"
+    # }, {
+        # "seleniumVersion": '3.4.0',
+        # "platform": "Windows 10",
+        # "browserName": "firefox",
+        # "version": "latest"
     }, {
         "seleniumVersion": '3.4.0',
         "platform": "OS X 10.13",


### PR DESCRIPTION
## Why
Significant drops in volume again, and failing to recover, nothing appears to error in our own app source code. We do not have good visibility on the Saucelab and Selenium side, the internals there. 

Stop the nohup.out file from getting written to, it may be consuming disk space over time.

![image](https://user-images.githubusercontent.com/8920574/106467258-63e20580-646a-11eb-8e14-97cd36d54c35.png)

## Solution
```
nohup ./script.sh >/dev/null 2>&1 &
```
writes stdout stderr into nothingness, rather than the `nohup.out` file, which is the default behavior.

## Testing
The only 'Saucelabs Failure Result's are for Windows+Firefox and OSX+Safari combo's. I do not think these are causing the failures.

[Sauce Result: failed](https://sentry.io/organizations/testorg-az/discover/results/?field=issue&field=event.type&field=title&field=server_name&field=timestamp&id=7788&name=DemoAutomation+Job+TestDataAutomation&project=5549642&query=issue%3ATEST-DATA-AUTOMATION-S&sort=-timestamp&statsPeriod=7d&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1) discovery query

example errors from Windows:Firefox:
https://sentry.io/organizations/testorg-az/issues/2148250367/

see the Context element:
![image](https://user-images.githubusercontent.com/8920574/106467517-c3401580-646a-11eb-8af7-adcbb0ba445a.png)
