### PR TITLE
Check pageload before Starting Test

### DIFF
--- a/frontend_tests/test_add_to_cart.py
+++ b/frontend_tests/test_add_to_cart.py
@@ -2,22 +2,29 @@ import pytest
 import time
 import yaml
 import random
-from sentry_sdk import set_tag
+import sentry_sdk
 
 @pytest.mark.usefixtures("driver")
 def test_add_to_cart(driver):
-    set_tag("test", "test_add_to_cart")
+    sentry_sdk.set_tag("test", "test_add_to_cart")
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         endpoints = data_loaded['react_endpoints']
 
     for endpoint in endpoints:
+        reported = False
         for i in range(random.randrange(20)):
             driver.get(endpoint)
 
-            buy_button = driver.find_element_by_css_selector('.item button')
-            for i in range(random.randrange(3) + 3):
-                buy_button.click()
+            # Buttons not be available if tools did not load in time
+            try:
+                buy_button = driver.find_element_by_css_selector('.item button')
+                for i in range(random.randrange(3) + 3):
+                    buy_button.click()
+                driver.find_element_by_css_selector('.sidebar button').click()
+            except Exception as err:
+                if reported == False:
+                    sentry_sdk.capture_exception(err)
+                reported = True
 
-            driver.find_element_by_css_selector('.sidebar button').click()
             time.sleep(random.randrange(3) + 3)

--- a/old.requirements.txt
+++ b/old.requirements.txt
@@ -1,0 +1,8 @@
+selenium==3.14.0
+sauceclient>=0.2.1
+pytest==4.4.0
+pytest-xdist
+requests
+pyyaml==3.11
+sentry-sdk==0.19.4
+python-dotenv==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 selenium==3.14.0
 sauceclient>=0.2.1
-pytest==4.4.0
+pytest==4.6.11
 pytest-xdist
 requests
 pyyaml==3.11


### PR DESCRIPTION
A lot of Selenium would error out because the driver could not find the buttons by CSS. This unavailability may be due to the tools in the web app failing to load (or delaying due to timeouts that are coded in)