### PR TITLE
2 Tests, Session Id, App Engine tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Docs:
 - https://cloud.google.com/sdk/gcloud/reference/scheduler/jobs/create/
 - https://docs.travis-ci.com/user/triggering-builds/
 
-## Sentry Documentation
+## Additional Documentation
 - https://docs.sentry.io/performance/distributed-tracing/
 - https://docs.sentry.io/performance/performance-metrics/
+- https://www.seleniumeasy.com/python/pytest-run-webdriver-tests-in-parallel

--- a/conftest.py
+++ b/conftest.py
@@ -129,7 +129,7 @@ def driver(request, browser_config):
 
     # If the test errors on not finding a button, then this should still execute
     # because it's part of Teardown which always runs
-    sentry_sdk.set_tag("sessionId", session_id)
+    sentry_sdk.set_tag("session_id", session_id)
     sentry_sdk.capture_message("Session done")
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)

--- a/conftest.py
+++ b/conftest.py
@@ -112,6 +112,7 @@ def driver(request, browser_config):
 
     # This is the test running
     yield browser
+    session_id = browser.session_id
 
     # Teardown starts here
     # report results
@@ -119,7 +120,7 @@ def driver(request, browser_config):
     sauce_result = "failed" if request.node.rep_call.failed else "passed"
     if sauce_result == "failed":
         sentry_sdk.set_context("sauce_result", {
-            "browser_session_id": browser.session_id,
+            "browser_session_id": session_id,
             "test_name": test_name
         })
         sentry_sdk.capture_message("Sauce Result: %s" % (sauce_result))
@@ -128,7 +129,7 @@ def driver(request, browser_config):
 
     # If the test errors on not finding a button, then this should still execute
     # because it's part of Teardown which always runs
-    sentry_sdk.set_tag("sessionId", browser.session_id)
+    sentry_sdk.set_tag("sessionId", session_id)
     sentry_sdk.capture_message("Session done")
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)

--- a/conftest.py
+++ b/conftest.py
@@ -110,7 +110,7 @@ def driver(request, browser_config):
         sentry_sdk.capture_message("Never created - case test failed: %s %s" % (browser.session_id, test_name))
         raise WebDriverException("Never created!")
 
-    # TODO this is where the test is run? it's blocking here?
+    # This is the test running
     yield browser
 
     # Teardown starts here
@@ -126,8 +126,10 @@ def driver(request, browser_config):
     browser.execute_script("sauce:job-result={}".format(sauce_result))
     browser.quit()
 
-    # TODO if the test errors on not finding a button, then will this line execute?
-    # sentry_sdk.capture_message("Finished browser.quit()")
+    # If the test errors on not finding a button, then this should still execute
+    # because it's part of Teardown which always runs
+    sentry_sdk.set_tag("sessionId", browser.session_id)
+    sentry_sdk.capture_message("Session done")
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_runtest_makereport(item, call):

--- a/frontend_tests/test_add_to_cart_2.py
+++ b/frontend_tests/test_add_to_cart_2.py
@@ -6,9 +6,9 @@ import sentry_sdk
 
 # If you print 'driver', it's not an object, it's "<selenium.webdriver.remote.webdriver.WebDriver (session="3955e7dab66c4172ad3d4a8808c0a67c")>"
 @pytest.mark.usefixtures("driver")
-def test_add_to_cart(driver):
+def test_add_to_cart_2(driver):
 
-    sentry_sdk.set_tag("py_test", "test_add_to_cart")
+    sentry_sdk.set_tag("py_test", "test_add_to_cart_2")
     with open('endpoints.yaml', 'r') as stream:
         data_loaded = yaml.safe_load(stream)
         endpoints = data_loaded['react_endpoints']
@@ -19,9 +19,7 @@ def test_add_to_cart(driver):
         clickedButtons = 0
         missedButtons = 0
 
-        # TODO each of these rand20 has to be for a different endpoint
         for i in range(random.randrange(20)):
-            # TODO - Driver was loaded/running already (Selenium), now is pulling the web app in, which is served by the endpoint?
             # Loads the homepage
             driver.get(endpoint)
 


### PR DESCRIPTION
## 2 tests
Half the endpoints used by 
test_add_to_cart.py

and the other half used by

test_add_to_cart_2.py

Run with -n 8.
## Session Id
Now captured on a Message called "Session done"

SessionId was not available in test_add_to_cart.py, so it's being set in a Message from conftest.py.

## TDA & App Engine
Test successfully.
Note that TDA working with App Engine hosted apps:
![image](https://user-images.githubusercontent.com/8920574/116901666-0edf9800-abef-11eb-9af5-7e4b32ab7113.png)
